### PR TITLE
refactor: add theme variables and responsive styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1,13 +1,24 @@
-body {font-family: sans-serif; margin: 0; padding: 0; font-size: 18px; line-height: 1.6; color: #222; background: #fff;}
-header {background: #dde; padding: 1rem; text-align: center; color: #222;}
+/* Theme variables */
+:root {
+  --color-bg: #fff;
+  --color-text: #222;
+  --color-primary: #0077cc;
+  --color-secondary: #dde;
+  --font-base: sans-serif;
+}
+
+body {font-family: var(--font-base); margin: 0; padding: 0; font-size: 18px; line-height: 1.6; color: var(--color-text); background: var(--color-bg);}
+header {background: var(--color-secondary); padding: 1rem; text-align: center; color: var(--color-text); position: sticky; top: 0; z-index: 100;}
 nav.tabs {display: flex; justify-content: center; gap: 0.5rem; margin-top: 1rem;}
-nav.tabs button {padding: 0.75rem 1rem; min-height: 44px; border: 1px solid #888; background: #f0f0f0; color: #222; border-radius: 5px; cursor: pointer;}
-nav.tabs button[aria-selected="true"] {background: #ccc;}
+nav.tabs button {padding: 0.75rem 1rem; min-height: 44px; border: 1px solid #888; background: var(--color-bg); color: var(--color-text); border-radius: 5px; cursor: pointer; transition: background 0.2s ease;}
+nav.tabs button:hover {background: var(--color-secondary);}
+nav.tabs button[aria-selected="true"] {background: var(--color-primary); color: #fff;}
 .icon {width: 1em; height: 1em; margin-right: 0.25rem; vertical-align: middle;}
 .container {max-width: 900px; margin: 1rem auto; padding: 1rem;}
 form {display: grid; gap: 0.5rem; max-width: 400px;}
 button {border-radius: 4px; min-height: 44px; padding: 0.5rem 1rem;}
-table {width: 100%; border-collapse: collapse; margin-top: 1rem;}
+table {width: 100%; border-collapse: collapse; overflow-y: auto; display: block; max-height: 60vh; margin-top: 1rem;}
+thead th {position: sticky; top: 0; background: var(--color-bg); z-index: 1;}
 th, td {border: 1px solid #ccc; padding: 0.5rem; text-align: left;}
 tbody tr:nth-child(odd) {background: #f9f9f9;}
 .hidden {display: none;}
@@ -17,10 +28,10 @@ tbody tr:nth-child(odd) {background: #f9f9f9;}
 
 #syncStatus {text-align: center;}
 #syncStatus.offline {color: #b00;}
-#manualSync {background: #0077cc; color: #fff; border: none;}
+#manualSync {background: var(--color-primary); color: var(--color-bg); border: none;}
 .sync-area {display: flex; justify-content: center; align-items: center; gap: 0.5rem; margin: 0.5rem;}
-#scanOverlay {position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); color: #fff; display: flex; align-items: center; justify-content: center; z-index: 1000;}
-#toast {position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%); padding: 0.75rem 1rem; border-radius: 4px; color: #fff; opacity: 0; transition: opacity 0.5s;}
+#scanOverlay {position: fixed; top: 0; left: 0; right: 0; bottom: 0; background: rgba(0,0,0,0.7); color: var(--color-bg); display: flex; align-items: center; justify-content: center; z-index: 1000;}
+#toast {position: fixed; bottom: 1rem; left: 50%; transform: translateX(-50%); padding: 0.75rem 1rem; border-radius: 4px; color: var(--color-bg); opacity: 0; transition: opacity 0.5s;}
 #toast.show {opacity: 1;}
 #toast.success {background: #2e7d32;}
 #toast.error {background: #c62828;}
@@ -38,6 +49,22 @@ tbody tr:nth-child(odd) {background: #f9f9f9;}
   margin-left: 0.5rem;
 }
 @keyframes spin {to {transform: rotate(360deg);}}
+
+@media (min-width: 768px) {
+  form {
+    grid-template-columns: 1fr 1fr;
+    column-gap: 1rem;
+  }
+  form label,
+  form input,
+  form select,
+  form button,
+  form .step-nav,
+  form div {
+    grid-column: span 2;
+  }
+  form fieldset {display: contents;}
+}
 
 @media (max-width: 600px){
   nav.tabs{flex-wrap: nowrap; overflow-x: auto;}


### PR DESCRIPTION
## Summary
- introduce CSS variables for theme colors and font
- enhance tab navigation with hover/active styles and transitions
- add sticky header, responsive form grid, and scrollable tables with sticky headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68adbe6f574c832e80799dff46ac2730